### PR TITLE
Update to version 3.5.3

### DIFF
--- a/globalmenu-extension/PKGBUILD
+++ b/globalmenu-extension/PKGBUILD
@@ -2,11 +2,11 @@
 
 # Based on Tom Kuther's PKGBUILD
 
-_bzr_rev=352
+_bzr_rev=465
 
 pkgbase=globalmenu-extension
 pkgname=('firefox-globalmenu' 'thunderbird-globalmenu')
-pkgver=3.2.7
+pkgver=3.5.3
 pkgrel=1
 pkgdesc="Global Menu Extensions for Firefox and Thunderbird"
 arch=('i686' 'x86_64')
@@ -14,7 +14,7 @@ url="https://launchpad.net/globalmenu-extension"
 license=('GPL' 'LGPL' 'MPL')
 makedepends=('bzr' 'autoconf2.13' 'libidl2' 'unzip' 'xulrunner' 'yasm' 'zip')
 
-_bzrtrunk=lp:globalmenu-extension/3.2
+_bzrtrunk=lp:globalmenu-extension/3.5
 
 build() {
   cd "${srcdir}"


### PR DESCRIPTION
Version 3.2.7 stopped working with Firefox 16.0.1
