### PR TITLE
New build version for accountsservice-ubuntu

### DIFF
--- a/accountsservice-ubuntu/PKGBUILD
+++ b/accountsservice-ubuntu/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: Ionut Biru <ibiru@archlinux.org>
 
 pkgname=accountsservice-ubuntu
-_ubuntu_rel=1ubuntu3
+_ubuntu_rel=1ubuntu4
 pkgver=0.6.29.${_ubuntu_rel}
 pkgrel=100
 pkgdesc="D-Bus interface for user account query and manipulation"


### PR DESCRIPTION
==> ERROR: Failure while downloading accountsservice_0.6.29-1ubuntu3.debian.tar.gz
I don't have test the build with this version
