### PR TITLE
python-regex updated to 0.1.20130605

### DIFF
--- a/python-regex/PKGBUILD
+++ b/python-regex/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgbase=python-regex
 pkgname=('python-regex' 'python2-regex')
-pkgver=0.1.20130521
+pkgver=0.1.20130605
 pkgrel=100
 pkgdesc="Alternative regular expression module"
 arch=('i686' 'x86_64')
@@ -12,13 +12,13 @@ groups=('unity-extra')
 makedepends=('python' 'python2' 'python-distribute' 'python2-distribute' 'python2-docutils')
 options=('!emptydirs')
 source=("http://ftp.de.debian.org/debian/pool/main/p/python-regex/python-regex_${pkgver}.orig.tar.gz")
-sha512sums=('9c7febfa60263fd098d154fb39eaf6fbb46fb5caf8a505f21abb8580a65e5f0a7d593df5819273d14d082d75aa802fafc47886db467fd28ea90b48885f871840')
+sha512sums=('82cd5229901b34f91401f3779372a4396bedf812607d1498ecfc0c7ff7bddf7141272fe1818666162fe9b48bc6cf1cac7c76812701262de6b5156d269e026c40')
 
 package_python-regex() {
   pkgdesc+=' (Python 3)'
   depends=('python')
 
-  cd "${srcdir}/regex-2013-05-21"
+  cd "${srcdir}/regex-2013-06-05"
   LANG=en_US.UTF-8 python setup.py install --root="${pkgdir}/" --optimize=1
 }
 
@@ -26,7 +26,7 @@ package_python2-regex() {
   pkgdesc+=' (Python 2)'
   depends=('python2')
 
-  cd "${srcdir}/regex-2013-05-21"
+  cd "${srcdir}/regex-2013-06-05"
   LANG=en_US.UTF-8 python2 setup.py install --root="${pkgdir}/" --optimize=1
 }
 


### PR DESCRIPTION
The previous one is no longer available for download.

Me again, just this minor fix to extra. Thanks!
