### PR TITLE
[indicator-multiload] Ported

### DIFF
--- a/README
+++ b/README
@@ -2,53 +2,54 @@ Unity-for-Arch-Extra: Themes, icons, and other additions that complete the Unity
 
 Themes, icons, etc.
 
-01: humanity-icon-theme          -> Icons used in Ubuntu < 10.04
-02: ubuntu-themes                -> Ubuntu icons and Ambiance and Radiance
-03: ubuntu-wallpapers            -> Wallpapers used in Ubuntu from 9.10 - 13.10
-04: ubuntu-sounds                -> The sound theme used in Ubuntu <= 12.04
-05: ubuntu-default-settings *    -> What the package name says
+01: humanity-icon-theme                  -> Icons used in Ubuntu < 10.04
+02: ubuntu-themes                        -> Ubuntu icons and Ambiance and Radiance
+03: ubuntu-wallpapers                    -> Wallpapers used in Ubuntu from 9.10 - 13.10
+04: ubuntu-sounds                        -> The sound theme used in Ubuntu <= 12.04
+05: ubuntu-default-settings *            -> What the package name says
 
 Applications
 
-06: lightdm-ubuntu               -> A cross-desktop lightweight display manager
-07: accountsservice-ubuntu       -> Daemon to query user account information
-08: lightdm-unity-greeter        -> The LightDM greeter for Unity
-09: messagingmenu-extension      -> Messaging indicator extension for TB
-10: liferea-indicator            -> Liferea with indicator support
-11: pidgin-libnotify-ubuntu      -> Pidgin notification plugin
-12: plasma-widget-menubar        -> KDE Plasma widget to display menubar
-13: xfce4-indicator-plugin       -> XFCE panel plugin to display indicators
-14: indicator-sync               -> Indicator for synchronization status
-15: indicator-cpufreq            -> CPU Frequency Indicator
-16: empathy-ubuntu               -> Empathy IM client with UOA support
-17: telepathy-indicator          -> Telepathy integration with the msg menu
-18: unity-tweak-tool             -> Tool to configure the Unity desktop
+06: lightdm-ubuntu                       -> A cross-desktop lightweight display manager
+07: accountsservice-ubuntu               -> Daemon to query user account information
+08: lightdm-unity-greeter                -> The LightDM greeter for Unity
+09: messagingmenu-extension              -> Messaging indicator extension for TB
+10: liferea-indicator                    -> Liferea with indicator support
+11: pidgin-libnotify-ubuntu              -> Pidgin notification plugin
+12: plasma-widget-menubar                -> KDE Plasma widget to display menubar
+13: xfce4-indicator-plugin               -> XFCE panel plugin to display indicators
+14: indicator-sync                       -> Indicator for synchronization status
+15: indicator-cpufreq                    -> CPU Frequency Indicator
+16: indicator-multiload                  -> System Load Indicator
+17: empathy-ubuntu                       -> Empathy IM client with UOA support
+18: telepathy-indicator                  -> Telepathy integration with the msg menu
+19: unity-tweak-tool                     -> Tool to configure the Unity desktop
 
 Unity Webapps
-19: python-polib                 -> Python library for messing with po files
-20: webapps-applications         -> Unity WebApps integration scripts
-21: webapps-greasemonkey         -> Firefox extension for user scripts
-22: unity-firefox-extension      -> Firefox extension for Unity integration
-23: webaccounts-browser-extension -> Web Accounts extension for FF and Chromium
-24: unity-webapps                -> See PKGBUILD for list of WebApps
+20: python-polib                         -> Python library for messing with po files
+21: webapps-applications                 -> Unity WebApps integration scripts
+22: webapps-greasemonkey                 -> Firefox extension for user scripts
+23: unity-firefox-extension              -> Firefox extension for Unity integration
+24: webaccounts-browser-extension        -> Web Accounts extension for FF and Chromium
+25: unity-webapps                        -> See PKGBUILD for list of WebApps
 
 LightDM remote session
-25: python3-pycurl               -> A Python 3 interface to libcurl
-26: thin-client-config-agent     -> Retrieve list of remote servers for a user
-27: remote-login-service         -> Service to track the remote servers to use
-28: lightdm-remote-session-uccsconfigure -> Session to configure UCCS
-29: libpam-freerdp               -> PAM module to auth. against an RDP server
-30: lightdm-remote-session-freerdp -> Session to login in with FreeRDP
+26: python3-pycurl                       -> A Python 3 interface to libcurl
+27: thin-client-config-agent             -> Retrieve list of remote servers for a user
+28: remote-login-service                 -> Service to track the remote servers to use
+29: lightdm-remote-session-uccsconfigure -> Session to configure UCCS
+30: libpam-freerdp                       -> PAM module to auth. against an RDP server
+31: lightdm-remote-session-freerdp       -> Session to login in with FreeRDP
 
 Everpad
-31: python-shiboken              -> CPython bindings generator for C++ libs
-32: python-pyside                -> Python bindings for Qt
-33: unity-singlet                -> Python library for building lenses & scopes
-34: python-keyring               -> Python library for accessing keyrings
-35: python2-oauth2               -> Python 2 library for OAuth 1.0
-36: python2-magic                -> Python 2 bindings for file
-37: python-regex                 -> Alternative Python regular expression module
-38: everpad                      -> Evernote client with Unity integration
+32: python-shiboken                      -> CPython bindings generator for C++ libs
+33: python-pyside                        -> Python bindings for Qt
+34: unity-singlet                        -> Python library for building lenses & scopes
+35: python-keyring                       -> Python library for accessing keyrings
+36: python2-oauth2                       -> Python 2 library for OAuth 1.0
+37: python2-magic                        -> Python 2 bindings for file
+38: python-regex                         -> Alternative Python regular expression module
+39: everpad                              -> Evernote client with Unity integration
 
 All of the PKGBUILD's have been checked with the namcap tool for consistency.
 

--- a/indicator-multiload/60x11-common_xdg_path
+++ b/indicator-multiload/60x11-common_xdg_path
@@ -1,0 +1,22 @@
+# This file is sourced by Xsession(5), not executed.
+# Add additionnal xdg paths depending on selected desktop session
+
+DEFAULT_XDG_CONFIG_DIRS='/etc/xdg'
+DEFAULT_XDG_DATA_DIRS='/usr/local/share/:/usr/share/'
+if [ -n "$DESKTOP_SESSION" ]; then
+  # readd default if was empty
+  if [ -z "$XDG_CONFIG_DIRS" ]; then
+    XDG_CONFIG_DIRS="$DEFAULT_XDG_CONFIG_DIRS"
+  fi
+  XDG_CONFIG_DIRS="$DEFAULT_XDG_CONFIG_DIRS"/xdg-"$DESKTOP_SESSION":"$XDG_CONFIG_DIRS"
+  export XDG_CONFIG_DIRS
+  # gnome is already added if gnome-session installed
+  if [ "$DESKTOP_SESSION" != "gnome" ]; then
+     if [ -z "$XDG_DATA_DIRS" ]; then
+       XDG_DATA_DIRS="$DEFAULT_XDG_DATA_DIRS"
+     fi
+     XDG_DATA_DIRS=/usr/share/"$DESKTOP_SESSION":"$XDG_DATA_DIRS"
+     export XDG_DATA_DIRS
+  fi
+fi
+

--- a/indicator-multiload/PKGBUILD
+++ b/indicator-multiload/PKGBUILD
@@ -1,0 +1,32 @@
+# Maintainer: Rafael Reggiani Manzo <rr.manzo@gmail.com>
+# Original PKGBUILD writen by Michael Egger <gcarq at yahoo dot com> can be found at: https://aur.archlinux.org/packages/indicator-multiload/
+
+pkgname=indicator-multiload
+pkgver=0.3
+pkgrel=100
+pkgdesc="System Load Indicator"
+arch=('i686' 'x86_64')
+url="https://launchpad.net/indicator-multiload"
+license=('GPLv3')
+groups=('unity-extra')
+depends=('unity' 'cairo' 'libappindicator' 'libgtop' 'glib2-ubuntu' 'gtk3-ubuntu')
+makedepends=('vala>=0.12' 'intltool' 'gcc')
+install=${pkgname}.install
+source=("https://launchpad.net/indicator-multiload/stable/${pkgver}/+download/indicator-multiload-${pkgver}.tar.gz"
+        "60x11-common_xdg_path")
+sha512sums=('812fafd5c2a3d080f04a1754ce083a6564f25a943f635d204e3e270dba2bf6a7e1858e7672680fbd344352831c283822046336f837c1cb6cb3375a38559e6c56'
+            '310da91b9082da6108a2e1c6a14268f9660f496b25d0a8166e3b23ab357fc22fc61a50f1e8aca1bbc5bbfcb2754af1d19e2db6169881f992d9881aa32e75df67')
+
+build() {
+  cd "$srcdir/$pkgname-$pkgver"
+  ./autogen.sh
+  ./configure --datarootdir=/usr/share
+  make
+}
+
+package() {
+  cd "$srcdir/$pkgname-$pkgver"
+  make DESTDIR="$pkgdir/" install
+  install -dm755 "$pkgdir/etc/X11/xinit/xinitrc.d/"
+  install -m755 "$srcdir/60x11-common_xdg_path" "$pkgdir/etc/X11/xinit/xinitrc.d/"
+}

--- a/indicator-multiload/indicator-multiload.install
+++ b/indicator-multiload/indicator-multiload.install
@@ -1,0 +1,7 @@
+post_install(){
+  printf "\nPlease run the following command in order to begin usin indicator-multiload:\n\n\tsource /etc/X11/xinit/xinitrc.d/60x11-common_xdg_path\n\nOr, you can reboot your computer.\n\n"
+}
+
+post_upgrade() {
+    post_install $1
+}


### PR DESCRIPTION
Hi, just finished to port it :)

I hope you could review if everything is according to your standards to the repository, but specially the file indicator-multiload/60x11-common_xdg_path.
It comes with xorg package in Ubuntu, but not in the Arch one. So I've copied it, since indicator-multiload needs the environment variable XDG_DATA_DIRS that it sets.

Also I've added the package to the README and fixed it's identation. If you don't like, just let me know :)
